### PR TITLE
Add degree symbol to Misc symbols

### DIFF
--- a/src/latexEquations.json
+++ b/src/latexEquations.json
@@ -317,6 +317,9 @@
             },
             {
                 "latex": "\\hat{x}"
+            },
+            {
+                "latex": "\\degree"
             }
         ]
     },


### PR DESCRIPTION
Adding an extra degree `\degree` symbol to the currently existing "Misc" symbols in the CK Editor Math Modal.
This is supported by KaTex as mentioned in the [Support Table.](https://katex.org/docs/0.11.1/support_table.html)